### PR TITLE
mat4.fromRotationTranslationScaleOrigin slight speedup

### DIFF
--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -1649,48 +1649,58 @@ mat4.fromRotationTranslationScale = function (out, q, v, s) {
  * @returns {mat4} out
  */
 mat4.fromRotationTranslationScaleOrigin = function (out, q, v, s, o) {
-  // Quaternion math
-  var x = q[0], y = q[1], z = q[2], w = q[3],
-      x2 = x + x,
-      y2 = y + y,
-      z2 = z + z,
+    // Quaternion math
+    var x = q[0], y = q[1], z = q[2], w = q[3],
+        x2 = x + x,
+        y2 = y + y,
+        z2 = z + z,
 
-      xx = x * x2,
-      xy = x * y2,
-      xz = x * z2,
-      yy = y * y2,
-      yz = y * z2,
-      zz = z * z2,
-      wx = w * x2,
-      wy = w * y2,
-      wz = w * z2,
+        xx = x * x2,
+        xy = x * y2,
+        xz = x * z2,
+        yy = y * y2,
+        yz = y * z2,
+        zz = z * z2,
+        wx = w * x2,
+        wy = w * y2,
+        wz = w * z2,
 
-      sx = s[0],
-      sy = s[1],
-      sz = s[2],
+        sx = s[0],
+        sy = s[1],
+        sz = s[2],
 
-      ox = o[0],
-      oy = o[1],
-      oz = o[2];
+        ox = o[0],
+        oy = o[1],
+        oz = o[2],
 
-  out[0] = (1 - (yy + zz)) * sx;
-  out[1] = (xy + wz) * sx;
-  out[2] = (xz - wy) * sx;
-  out[3] = 0;
-  out[4] = (xy - wz) * sy;
-  out[5] = (1 - (xx + zz)) * sy;
-  out[6] = (yz + wx) * sy;
-  out[7] = 0;
-  out[8] = (xz + wy) * sz;
-  out[9] = (yz - wx) * sz;
-  out[10] = (1 - (xx + yy)) * sz;
-  out[11] = 0;
-  out[12] = v[0] + ox - (out[0] * ox + out[4] * oy + out[8] * oz);
-  out[13] = v[1] + oy - (out[1] * ox + out[5] * oy + out[9] * oz);
-  out[14] = v[2] + oz - (out[2] * ox + out[6] * oy + out[10] * oz);
-  out[15] = 1;
+        out0 = (1 - (yy + zz)) * sx,
+        out1 = (xy + wz) * sx,
+        out2 = (xz - wy) * sx,
+        out4 = (xy - wz) * sy,
+        out5 = (1 - (xx + zz)) * sy,
+        out6 = (yz + wx) * sy,
+        out8 = (xz + wy) * sz,
+        out9 = (yz - wx) * sz,
+        out10 = (1 - (xx + yy)) * sz;
 
-  return out;
+    out[0] = out0;
+    out[1] = out1;
+    out[2] = out2;
+    out[3] = 0;
+    out[4] = out4;
+    out[5] = out5;
+    out[6] = out6;
+    out[7] = 0;
+    out[8] = out8;
+    out[9] = out9;
+    out[10] = out10;
+    out[11] = 0;
+    out[12] = v[0] + ox - (out0 * ox + out4 * oy + out8 * oz);
+    out[13] = v[1] + oy - (out1 * ox + out5 * oy + out9 * oz);
+    out[14] = v[2] + oz - (out2 * ox + out6 * oy + out10 * oz);
+    out[15] = 1;
+
+    return out;
 };
 
 /**


### PR DESCRIPTION
Cached local array accesses.

I doubt many people will notice the difference.
My library calls this function possibly millions of times per second, so every bit of speed counts.